### PR TITLE
Move from application graph to public graph

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -19,7 +19,7 @@ defmodule Acl.UserGroups.Config do
         useage: [:read],
         access: %AlwaysAccessible{},
         graphs: [ %GraphSpec{
-                    graph: "http://mu.semte.ch/application",
+                    graph: "http://mu.semte.ch/graphs/public",
                     constraint: %ResourceConstraint{
                       resource_types: [
                         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
@@ -34,7 +34,14 @@ defmodule Acl.UserGroups.Config do
                         "http://data.lblod.info/vocabularies/leidinggevenden/FunctionarisStatusCode",
                         "http://www.w3.org/ns/person#Person",
                         "http://www.w3.org/ns/prov#Location"
-                    ] } } ] }
+                    ] } } ] },
+      # // CLEANUP
+      #
+      %GraphCleanup{
+        originating_graph: "http://mu.semte.ch/application",
+        useage: [:write],
+        name: "clean"
+      }
     ]
   end
 end

--- a/config/migrations/20210226094437-move-to-public-graph.sparql
+++ b/config/migrations/20210226094437-move-to-public-graph.sparql
@@ -1,0 +1,1 @@
+MOVE <http://mu.semte.ch/application> TO <http://mu.semte.ch/graphs/public>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,8 @@ services:
     ports:
       - "8891:8890"
     restart: "no"
+  migrations:
+    restart: "no"
   database:
     restart: "no"
   file:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,8 +1,14 @@
 version: '3.4'
 services:
+  leidinggevenden:
+    restart: "no"
   identifier:
     ports:
       - "80:80"
+    restart: "no"
+  dispatcher:
+    restart: "no"
+  database:
     restart: "no"
   virtuoso:
     ports:
@@ -10,7 +16,17 @@ services:
     restart: "no"
   migrations:
     restart: "no"
-  database:
+  cache:
+    restart: "no"
+  resource:
+    restart: "no"
+  deltanotifier:
+    restart: "no"
+  sitemap:
+    restart: "no"
+  export:
+    restart: "no"
+  filehost:
     restart: "no"
   file:
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,18 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  migrations:
+    image: semtech/mu-migrations-service:0.6.0
+    environment:
+      MU_SPARQL_TIMEOUT: '300'
+    links:
+      - virtuoso:database
+    volumes:
+      - ./config/migrations:/data/migrations
+    restart: always
+    labels:
+      - "logging=true"
+    logging: *default-logging
   cache:
     image: semtech/mu-cache:2.0.1
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
   identifier:
     image: semtech/mu-identifier:1.9.0
     environment:
-      DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER: "[{\"variables\":[],\"name\":\"public\"}]"
       DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER: "*"
+      DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER: "[{\"variables\":[],\"name\":\"public\"}]"
     restart: always
     labels:
       - "logging=true"
@@ -136,13 +136,15 @@ services:
     environment:
       SYNC_BASE_URL: 'https://loket.lblod.info' # replace with link to Loket API
       SYNC_FILES_PATH: '/sync/leidinggevenden/files'
-      MU_APPLICATION_GRAPH: 'http://mu.semte.ch/application'
+      MU_APPLICATION_GRAPH: 'http://mu.semte.ch/graphs/public'
     restart: always
     labels:
       - "logging=true"
     logging: *default-logging
   leidinggevenden-producer:
     image: lblod/simple-delta-file-producer:0.0.3
+    environment:
+      FILE_GRAPH: 'http://mu.semte.ch/graphs/public'
     volumes:
       - ./data/files:/share
       - ./config/producer/:/config/


### PR DESCRIPTION
When testing you will notice 3 triples still in the application-graph. That is to be expected as these come from the migration service.

**When deploying, make sure the import service drops triples in the public graph.**